### PR TITLE
(error) fix error due to bracket

### DIFF
--- a/src/Components/css/LeafletSearch.css
+++ b/src/Components/css/LeafletSearch.css
@@ -164,6 +164,7 @@
     height: 100px;
     z-index: 1001;
     top: 38px
+}
 
 #guite-txt {
     padding-left: 2%;


### PR DESCRIPTION
LeafletSearch.css 에서 .popup에서 중괄호 안닫아 발생하는 오류 해결